### PR TITLE
Fix logs lost on complete

### DIFF
--- a/app/models/logging_worker/job_run.rb
+++ b/app/models/logging_worker/job_run.rb
@@ -5,12 +5,19 @@ class LoggingWorker::JobRun < ApplicationRecord
   end
 
   def logger
-    @logger ||= Logger.new(StringIO.new(log))
+    @io ||= StringIO.new
+    @logger ||= Logger.new(@io)
   end
 
-  def flush_log!
-    log_will_change!
-    save!
+  def flush_log!(save_to_db = true)
+    @io.rewind
+    content = @io.read
+    self.log += content
+    save! if save_to_db
+    @io.close
+    @logger.close
+    @io = nil
+    @logger = nil
   end
 
   def do_not_record!
@@ -27,6 +34,8 @@ class LoggingWorker::JobRun < ApplicationRecord
     else
       self.successful = false if successful.nil?
       self.completed_at = Time.now
+      logger # make sure we've got it
+      flush_log!(false)
       save!
     end
   end

--- a/lib/logging_worker/version.rb
+++ b/lib/logging_worker/version.rb
@@ -1,3 +1,3 @@
 module LoggingWorker
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/lib/logging_worker/worker.rb
+++ b/lib/logging_worker/worker.rb
@@ -19,8 +19,6 @@ module LoggingWorker
       job_run.arguments = args
       job_run.save!
 
-      job_run.log_will_change!
-
       super
 
       job_run.successful!

--- a/spec/models/job_run_spec.rb
+++ b/spec/models/job_run_spec.rb
@@ -10,6 +10,7 @@ describe JobRun do
   specify "logging during the run" do
     job_run = JobRun.new
     job_run.logger.info("test")
+    job_run.flush_log!
     expect(job_run.log).to include("test")
   end
 end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -79,9 +79,11 @@ describe LoggingWorker::Worker do
     run.flush_log!
     expect(LoggingWorker::JobRun.first.log).to include("Test this")
     expect(LoggingWorker::JobRun.first.log).to include("Testing more")
+    run.logger.info "Testing even more"
     run.completed!
     expect(LoggingWorker::JobRun.first.log).to include("Test this")
     expect(LoggingWorker::JobRun.first.log).to include("Testing more")
+    expect(LoggingWorker::JobRun.first.log).to include("Testing even more")
   end
 
   specify "self desctruct on complete" do


### PR DESCRIPTION
Because the log wasn't left knowing there was a change, the last
messages after a flush but before calling complete were lost.

This adjusts to no longer shadow the column, and instead on every flush
adds the new logger content to the column.